### PR TITLE
Fix ui layout issues after .NET8/9 migration

### DIFF
--- a/SourceCode/AgDiag/Forms/FormLoop.Designer.cs
+++ b/SourceCode/AgDiag/Forms/FormLoop.Designer.cs
@@ -1097,8 +1097,8 @@ namespace AgDiag
             // 
             // FormLoop
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 18F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Cyan;
             this.ClientSize = new System.Drawing.Size(476, 529);
             this.Controls.Add(this.panelBack);

--- a/SourceCode/AgIO/Source/Forms/FormEthernet.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormEthernet.designer.cs
@@ -230,8 +230,8 @@
             // 
             // FormEthernet
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 19F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
             this.ClientSize = new System.Drawing.Size(772, 254);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormEventViewer.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormEventViewer.Designer.cs
@@ -73,8 +73,8 @@
             // 
             // FormEventViewer
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.ClientSize = new System.Drawing.Size(664, 365);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormKeyboard.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormKeyboard.Designer.cs
@@ -55,8 +55,8 @@
             // 
             // FormKeyboard
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.ClientSize = new System.Drawing.Size(940, 460);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormLoop.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormLoop.Designer.cs
@@ -1099,8 +1099,8 @@ namespace AgIO
             // 
             // FormLoop
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 18F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
             this.ClientSize = new System.Drawing.Size(734, 486);

--- a/SourceCode/AgIO/Source/Forms/FormNtrip.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormNtrip.Designer.cs
@@ -843,8 +843,8 @@
             // 
             // FormNtrip
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(767, 648);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormNumeric.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormNumeric.Designer.cs
@@ -112,8 +112,8 @@
             // 
             // FormNumeric
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.ClientSize = new System.Drawing.Size(460, 545);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormPGN.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormPGN.designer.cs
@@ -97,8 +97,8 @@
             // 
             // FormPGN
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
             this.ClientSize = new System.Drawing.Size(291, 510);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormProfiles.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormProfiles.designer.cs
@@ -204,8 +204,8 @@
             // 
             // FormProfiles
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.ClientSize = new System.Drawing.Size(576, 394);
             this.Controls.Add(this.label3);

--- a/SourceCode/AgIO/Source/Forms/FormRadio.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormRadio.Designer.cs
@@ -374,8 +374,8 @@ namespace AgIO
             // 
             // FormRadio
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(820, 627);
             this.ControlBox = false;
             this.Controls.Add(this.labelChannels);

--- a/SourceCode/AgIO/Source/Forms/FormRadioChannel.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormRadioChannel.Designer.cs
@@ -187,8 +187,8 @@ namespace AgIO
             // 
             // FormRadioChannel
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(447, 269);
             this.ControlBox = false;
             this.Controls.Add(this.tbLon);

--- a/SourceCode/AgIO/Source/Forms/FormSerialMonitor.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormSerialMonitor.designer.cs
@@ -245,8 +245,8 @@
             // 
             // FormSerialMonitor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 19F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
             this.ClientSize = new System.Drawing.Size(539, 361);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormSerialPass.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormSerialPass.designer.cs
@@ -263,8 +263,8 @@
             // 
             // FormSerialPass
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 19F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.ClientSize = new System.Drawing.Size(702, 497);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormSource.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormSource.Designer.cs
@@ -190,8 +190,8 @@
             // 
             // FormSource
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(985, 610);
             this.Controls.Add(this.btnSort);
             this.Controls.Add(this.button1);

--- a/SourceCode/AgIO/Source/Forms/FormTimedMessage.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormTimedMessage.Designer.cs
@@ -62,8 +62,8 @@
             // 
             // FormTimedMessage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.LightSalmon;
             this.ClientSize = new System.Drawing.Size(268, 147);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormUDP.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormUDP.Designer.cs
@@ -666,8 +666,8 @@
             // 
             // FormUDP
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 19F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.ClientSize = new System.Drawing.Size(861, 584);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormUDPMonitor.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormUDPMonitor.designer.cs
@@ -211,8 +211,8 @@
             // 
             // FormUDPMonitor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 19F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
             this.ClientSize = new System.Drawing.Size(456, 291);
             this.ControlBox = false;

--- a/SourceCode/AgIO/Source/Forms/FormYes.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/FormYes.designer.cs
@@ -61,8 +61,8 @@
             // 
             // FormYes
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(200)))), ((int)(((byte)(200)))));
             this.ClientSize = new System.Drawing.Size(606, 360);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Config/ConfigSummaryControl.Designer.cs
+++ b/SourceCode/GPS/Forms/Config/ConfigSummaryControl.Designer.cs
@@ -332,8 +332,8 @@
             // 
             // ConfigSummaryControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.Controls.Add(this.label2);
             this.Controls.Add(this.labelWidth);

--- a/SourceCode/GPS/Forms/Config/ConfigVehicleControl.Designer.cs
+++ b/SourceCode/GPS/Forms/Config/ConfigVehicleControl.Designer.cs
@@ -746,8 +746,8 @@
             // 
             // ConfigVehicleControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.Controls.Add(this.lblOpacityPercent);
             this.Controls.Add(this.labelVehicleGroupBox);

--- a/SourceCode/GPS/Forms/Field/FormAgShareDownloader.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormAgShareDownloader.Designer.cs
@@ -166,8 +166,8 @@
             // FormAgShareDownloader
             // 
             this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.AutoValidate = System.Windows.Forms.AutoValidate.Disable;
             this.ClientSize = new System.Drawing.Size(1161, 663);

--- a/SourceCode/GPS/Forms/Field/FormBndTool.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormBndTool.Designer.cs
@@ -607,8 +607,8 @@
             // 
             // FormBndTool
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.LightGray;
             this.ClientSize = new System.Drawing.Size(1006, 726);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Field/FormBoundary.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormBoundary.Designer.cs
@@ -353,8 +353,8 @@
             // 
             // FormBoundary
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Cyan;
             this.ClientSize = new System.Drawing.Size(1084, 310);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Field/FormBoundaryPlayer.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormBoundaryPlayer.Designer.cs
@@ -306,8 +306,8 @@
             // 
             // FormBoundaryPlayer
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(249, 483);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Field/FormBuildBoundaryFromTracks.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormBuildBoundaryFromTracks.Designer.cs
@@ -268,8 +268,8 @@ namespace AgOpenGPS.Forms.Field
             // 
             // FormBuildBoundaryFromTracks
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.ClientSize = new System.Drawing.Size(1008, 729);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormEnterFlag.Designer.cs
@@ -248,8 +248,8 @@
             // 
             // FormEnterFlag
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(771, 266);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Field/FormFlags.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormFlags.Designer.cs
@@ -303,8 +303,8 @@
             // 
             // FormFlags
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.ClientSize = new System.Drawing.Size(300, 318);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Field/FormMap.Designer.cs
+++ b/SourceCode/GPS/Forms/Field/FormMap.Designer.cs
@@ -343,8 +343,8 @@
             // 
             // FormMap
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(1130, 780);

--- a/SourceCode/GPS/Forms/FormAgShareSettings.Designer.cs
+++ b/SourceCode/GPS/Forms/FormAgShareSettings.Designer.cs
@@ -221,8 +221,8 @@
             // 
             // FormAgShareSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(584, 373);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/FormDialog.Designer.cs
+++ b/SourceCode/GPS/Forms/FormDialog.Designer.cs
@@ -116,8 +116,8 @@
             // 
             // FormDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Red;
             this.ClientSize = new System.Drawing.Size(800, 229);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/FormEventViewer.Designer.cs
+++ b/SourceCode/GPS/Forms/FormEventViewer.Designer.cs
@@ -73,8 +73,8 @@
             // 
             // FormEventViewer
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.ClientSize = new System.Drawing.Size(681, 365);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/FormSaving.Designer.cs
+++ b/SourceCode/GPS/Forms/FormSaving.Designer.cs
@@ -85,8 +85,8 @@
             // 
             // FormSaving
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(192)))), ((int)(((byte)(0)))));
             this.ClientSize = new System.Drawing.Size(933, 491);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/FormShiftPos.Designer.cs
+++ b/SourceCode/GPS/Forms/FormShiftPos.Designer.cs
@@ -292,8 +292,8 @@
             // 
             // FormShiftPos
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(658, 674);
             this.ControlBox = false;
             this.Controls.Add(this.label7);

--- a/SourceCode/GPS/Forms/FormTimedMessage.Designer.cs
+++ b/SourceCode/GPS/Forms/FormTimedMessage.Designer.cs
@@ -75,8 +75,8 @@
             // 
             // FormTimedMessage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Red;
             this.ClientSize = new System.Drawing.Size(276, 134);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/FormYes.designer.cs
+++ b/SourceCode/GPS/Forms/FormYes.designer.cs
@@ -66,8 +66,8 @@
             // 
             // FormYes
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(254)))), ((int)(((byte)(170)))), ((int)(((byte)(170)))));
             this.ClientSize = new System.Drawing.Size(881, 459);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Form_About.Designer.cs
+++ b/SourceCode/GPS/Forms/Form_About.Designer.cs
@@ -281,8 +281,8 @@
             // 
             // Form_About
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(984, 644);
             this.ControlBox = false;
             this.Controls.Add(this.label13);

--- a/SourceCode/GPS/Forms/Form_First.Designer.cs
+++ b/SourceCode/GPS/Forms/Form_First.Designer.cs
@@ -247,8 +247,8 @@
             // 
             // Form_First
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Lavender;
             this.ClientSize = new System.Drawing.Size(1026, 659);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Form_Help.Designer.cs
+++ b/SourceCode/GPS/Forms/Form_Help.Designer.cs
@@ -153,8 +153,8 @@
             // 
             // Form_Help
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.ClientSize = new System.Drawing.Size(689, 402);

--- a/SourceCode/GPS/Forms/Form_Keys.Designer.cs
+++ b/SourceCode/GPS/Forms/Form_Keys.Designer.cs
@@ -647,8 +647,8 @@
             // 
             // Form_Keys
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(895, 686);
             this.ControlBox = false;
             this.Controls.Add(this.label25);

--- a/SourceCode/GPS/Forms/Guidance/FormABDraw.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormABDraw.Designer.cs
@@ -433,8 +433,8 @@
             // 
             // FormABDraw
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(1006, 703);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormBuildTracks.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormBuildTracks.Designer.cs
@@ -1850,8 +1850,8 @@
             // 
             // FormBuildTracks
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(1924, 757);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormGrid.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormGrid.Designer.cs
@@ -158,8 +158,8 @@
             // 
             // FormGrid
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(605, 501);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormHeadAche.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormHeadAche.Designer.cs
@@ -532,8 +532,8 @@
             // 
             // FormHeadAche
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(1006, 709);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormHeadLine.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormHeadLine.Designer.cs
@@ -475,8 +475,8 @@
             // 
             // FormHeadLine
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(1006, 726);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormNudge.designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormNudge.designer.cs
@@ -257,8 +257,8 @@
             // 
             // FormNudge
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.LightSteelBlue;
             this.ClientSize = new System.Drawing.Size(180, 320);
             this.Controls.Add(this.lblOffset);

--- a/SourceCode/GPS/Forms/Guidance/FormQuickAB.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormQuickAB.Designer.cs
@@ -614,8 +614,8 @@
             // 
             // FormQuickAB
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(763, 654);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormQuickAB.resx
+++ b/SourceCode/GPS/Forms/Guidance/FormQuickAB.resx
@@ -1,64 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -112,12 +53,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>

--- a/SourceCode/GPS/Forms/Guidance/FormRefNudge.designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormRefNudge.designer.cs
@@ -218,8 +218,8 @@
             // 
             // FormRefNudge
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.LightCoral;
             this.ClientSize = new System.Drawing.Size(223, 396);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormSmoothAB.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormSmoothAB.Designer.cs
@@ -136,8 +136,8 @@
             // 
             // FormSmoothAB
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(231, 393);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormTram.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormTram.Designer.cs
@@ -323,8 +323,8 @@
             // 
             // FormTram
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(353, 354);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Guidance/FormTramLine.Designer.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormTramLine.Designer.cs
@@ -476,8 +476,8 @@
             // 
             // FormTramLine
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(1004, 701);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Inputs/FormKeyboard.Designer.cs
+++ b/SourceCode/GPS/Forms/Inputs/FormKeyboard.Designer.cs
@@ -90,9 +90,9 @@
             this.btnCharRight.Click += new System.EventHandler(this.btnCharRight_Click);
             // 
             // FormKeyboard
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.ClientSize = new System.Drawing.Size(942, 454);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Inputs/FormNumeric.Designer.cs
+++ b/SourceCode/GPS/Forms/Inputs/FormNumeric.Designer.cs
@@ -113,8 +113,8 @@
             // 
             // FormNumeric
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.ClientSize = new System.Drawing.Size(460, 545);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Pickers/FormColorPicker.Designer.cs
+++ b/SourceCode/GPS/Forms/Pickers/FormColorPicker.Designer.cs
@@ -354,8 +354,8 @@
             // 
             // FormColorPicker
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(127)))), ((int)(((byte)(127)))), ((int)(((byte)(127)))));
             this.ClientSize = new System.Drawing.Size(591, 615);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Pickers/FormDrivePicker.Designer.cs
+++ b/SourceCode/GPS/Forms/Pickers/FormDrivePicker.Designer.cs
@@ -105,8 +105,8 @@
             // 
             // FormDrivePicker
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(971, 407);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Pickers/FormFilePicker.Designer.cs
+++ b/SourceCode/GPS/Forms/Pickers/FormFilePicker.Designer.cs
@@ -164,8 +164,8 @@
             // 
             // FormFilePicker
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(991, 578);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Pickers/FormRecordPicker.Designer.cs
+++ b/SourceCode/GPS/Forms/Pickers/FormRecordPicker.Designer.cs
@@ -161,8 +161,8 @@ namespace AgOpenGPS.Forms.Pickers
             // 
             // FormRecordPicker
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(972, 578);
             this.ControlBox = false;
             this.Controls.Add(this.labelPathOff);

--- a/SourceCode/GPS/Forms/Profiles/FormLoadProfile.Designer.cs
+++ b/SourceCode/GPS/Forms/Profiles/FormLoadProfile.Designer.cs
@@ -139,8 +139,8 @@
             // 
             // FormLoadProfile
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(639, 437);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Profiles/FormNewProfile.Designer.cs
+++ b/SourceCode/GPS/Forms/Profiles/FormNewProfile.Designer.cs
@@ -153,8 +153,8 @@
             // 
             // FormNewProfile
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.ClientSize = new System.Drawing.Size(637, 390);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Settings/FormButtonsRightPanel.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormButtonsRightPanel.Designer.cs
@@ -509,8 +509,8 @@
             // 
             // FormButtonsRightPanel
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Silver;
             this.ClientSize = new System.Drawing.Size(741, 664);
             this.ControlBox = false;

--- a/SourceCode/GPS/Forms/Settings/FormCorrection.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormCorrection.Designer.cs
@@ -256,8 +256,8 @@
             // 
             // FormCorrection
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.ClientSize = new System.Drawing.Size(809, 424);
             this.Controls.Add(this.btnPoleOrMoving);

--- a/SourceCode/GPS/Forms/Settings/FormGraphHeading.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormGraphHeading.Designer.cs
@@ -256,8 +256,8 @@
             // 
             // FormHeadingGraph
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.ClientSize = new System.Drawing.Size(495, 470);
             this.Controls.Add(this.label4);

--- a/SourceCode/GPS/Forms/Settings/FormGraphSteer.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormGraphSteer.Designer.cs
@@ -242,8 +242,8 @@
             // 
             // FormSteerGraph
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.ClientSize = new System.Drawing.Size(498, 312);
             this.Controls.Add(this.label2);

--- a/SourceCode/GPS/Forms/Settings/FormGraphXTE.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormGraphXTE.Designer.cs
@@ -242,8 +242,8 @@
             // 
             // FormXTEGraph
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.ClientSize = new System.Drawing.Size(441, 216);
             this.Controls.Add(this.lblPWM);

--- a/SourceCode/GPS/Forms/Settings/FormSimCoords.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormSimCoords.Designer.cs
@@ -202,8 +202,8 @@
             // 
             // FormSimCoords
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Gainsboro;
             this.BackgroundImage = global::AgOpenGPS.Properties.Resources.LatLon;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;

--- a/SourceCode/GPS_Out/Source/Form1.Designer.cs
+++ b/SourceCode/GPS_Out/Source/Form1.Designer.cs
@@ -905,8 +905,8 @@
             // 
             // frmStart
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.ClientSize = new System.Drawing.Size(626, 536);
             this.Controls.Add(this.tabControl1);

--- a/SourceCode/GPS_Out/Source/frmHelp.Designer.cs
+++ b/SourceCode/GPS_Out/Source/frmHelp.Designer.cs
@@ -65,8 +65,8 @@ namespace RateController
             // 
             // frmHelp
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(484, 281);
             this.Controls.Add(this.panel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;

--- a/SourceCode/Keypad/GenericKeypad.Designer.cs
+++ b/SourceCode/Keypad/GenericKeypad.Designer.cs
@@ -32,8 +32,8 @@
             // 
             // GenericKeypad
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Name = "GenericKeypad";
             this.Size = new System.Drawing.Size(325, 303);
             this.ResumeLayout(false);

--- a/SourceCode/Keypad/Keyboard.Designer.cs
+++ b/SourceCode/Keypad/Keyboard.Designer.cs
@@ -1066,9 +1066,9 @@
             this.d12.Click += new System.EventHandler(this.BtnClick);
             // 
             // Keyboard
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.GradientActiveCaption;
             this.Controls.Add(this.d12);
             this.Controls.Add(this.d11);

--- a/SourceCode/Keypad/NumKeypad.Designer.cs
+++ b/SourceCode/Keypad/NumKeypad.Designer.cs
@@ -320,8 +320,8 @@
             // 
             // NumKeypad
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.Controls.Add(this.btnBackSpace);
             this.Controls.Add(this.btnOK);

--- a/SourceCode/ModSim/Source/Forms/FormSim.Designer.cs
+++ b/SourceCode/ModSim/Source/Forms/FormSim.Designer.cs
@@ -1750,8 +1750,8 @@ namespace ModSim
             // 
             // FormSim
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 18F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
             this.ClientSize = new System.Drawing.Size(713, 520);

--- a/SourceCode/ModSim/Source/Forms/FormTimedMessage.Designer.cs
+++ b/SourceCode/ModSim/Source/Forms/FormTimedMessage.Designer.cs
@@ -62,8 +62,8 @@
             // 
             // FormTimedMessage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.LightSalmon;
             this.ClientSize = new System.Drawing.Size(272, 151);
             this.ControlBox = false;

--- a/SourceCode/ModSim/Source/Forms/FormYes.designer.cs
+++ b/SourceCode/ModSim/Source/Forms/FormYes.designer.cs
@@ -60,8 +60,8 @@
             // 
             // FormYes
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(200)))), ((int)(((byte)(200)))));
             this.ClientSize = new System.Drawing.Size(241, 225);
             this.ControlBox = false;


### PR DESCRIPTION
Fixes ui layout issues after .NET8/9 migration

Problems found in Windows11 with 100% scaling setting.

Problematic forms:
<img width="796" height="427" alt="kuva" src="https://github.com/user-attachments/assets/42a59909-a29f-4f67-b4e8-61334ab23b6d" />
<img width="1085" height="491" alt="kuva" src="https://github.com/user-attachments/assets/f476c2d7-ec66-4c59-8606-5baf06a5164d" />
<img width="462" height="577" alt="kuva" src="https://github.com/user-attachments/assets/3eeeac2a-1f5a-473a-b742-240bb298607c" />
<img width="256" height="353" alt="kuva" src="https://github.com/user-attachments/assets/9c8a93a9-0a06-4485-bd6b-7f9f351af174" />


Change occurances in the project
from
```
            this.AutoScaleDimensions = new System.Drawing.SizeF(**F, **F);
            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
```
to
```
            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
```